### PR TITLE
Add SEO and GEO info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a simple React-based web application that provides a user-friendly interface for encoding and decoding text to and from Base64 format. The app now supports full Unicode input using custom encoding utilities and exposes a server API for processing large payloads.
 
+### Official Website
+
+[https://base64.dcesares.dev/](https://base64.dcesares.dev/)
+
 ### Features
 
 * **Toggle between Encode and Decode modes:** A visually appealing toggle switch allows users to seamlessly switch between encoding and decoding functionalities.
@@ -65,3 +69,15 @@ Contributions are welcome! If you find any issues or have suggestions for improv
 ### License
 
 This project is licensed under the MIT License.
+
+### SEO and GEO
+
+This project applies common search engine optimization (SEO) patterns including descriptive meta tags and structured data. The code is also formatted to help generative engines (GEO) understand the content. Results may vary and no ranking is guaranteed.
+
+### Author
+
+[Isaac D'Césares](https://dcesares.dev)
+
+### Disclaimer
+
+This tool is provided for educational purposes. There is no guarantee of performance for SEO or GEO techniques. Use it at your own risk.

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "jest": "^29.7.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17"
-  }
+  },
+  "author": "Isaac D'Césares <https://dcesares.dev>"
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -93,7 +93,32 @@ export default function Home() {
         <title>{title}</title>
         <meta name="description" content={description} />
         <meta name="keywords" content="base64, encoder, decoder, online tool, text conversion" />
-      </Head>
+    <meta name="author" content="Isaac D&apos;C&eacute;sares" />
+    <link rel="canonical" href="https://base64.dcesares.dev/" />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://base64.dcesares.dev/" />
+    <meta property="og:image" content="/next.svg" />
+    <meta name="twitter:card" content="summary_large_image" />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "WebApplication",
+                name: "Base64 Encoder/Decoder",
+                url: "https://base64.dcesares.dev/",
+                author: {
+                  "@type": "Person",
+                  name: "Isaac D'Césares",
+                  url: "https://dcesares.dev",
+                },
+              }),
+            }}
+          />
+  </Head>
       <main>
         <div className={`min-h-screen bg-gradient-to-br ${bgGradient} transition-all duration-500 ease-in-out flex flex-col items-center justify-center p-4`}>
           <div className={`bg-white rounded-lg shadow-lg p-6 w-full max-w-md space-y-6 mb-4 transition-all duration-300 ease-in-out ${isTransitioning ? 'opacity-0 transform translate-y-4' : 'opacity-100 transform translate-y-0'}`}>


### PR DESCRIPTION
## Summary
- improve SEO meta tags and add structured data
- cite author and website in page metadata
- document SEO/GEO approach and disclaimer
- add author field in package.json
- fix SEO URLs and add official website info

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859689d5ab0832c83e26c92962e3edd